### PR TITLE
JSR publish job, but the name is `deno-deploy` (#70)

### DIFF
--- a/.github/workflows/cd-jsr.yml
+++ b/.github/workflows/cd-jsr.yml
@@ -5,7 +5,7 @@ on:
     tags: v*.*.**
 
 jobs:
-  deno-deploy:
+  jsr-publish:
     runs-on: ubuntu-latest
 
     permissions:


### PR DESCRIPTION
Close #70

## Checks

No checks for infra maintaining.
